### PR TITLE
Correctly handle missing feed_info.txt GTFS file

### DIFF
--- a/src/main/java/it/osm/gtfs/input/GTFSParser.java
+++ b/src/main/java/it/osm/gtfs/input/GTFSParser.java
@@ -355,6 +355,8 @@ public class GTFSParser {
 
     public static GTFSFeedInfo readFeedInfo(String gtfsFeedInfoPath) throws IOException {
 
+        if (!Files.isRegularFile(Paths.get(gtfsFeedInfoPath))) return null;
+
         GTFSFeedInfo gtfsFeedInfo;
 
         String thisLine;

--- a/src/main/java/it/osm/gtfs/output/OSMRelationImportGenerator.java
+++ b/src/main/java/it/osm/gtfs/output/OSMRelationImportGenerator.java
@@ -87,7 +87,7 @@ public class OSMRelationImportGenerator {
             buffer.append("<tag k='gtfs:agency_id' v='" + agencyId + "' />\n");
         }
 
-        if (gtfsFeedInfo.getVersion() != null && !gtfsFeedInfo.getVersion().isBlank()) {
+        if (gtfsFeedInfo != null && gtfsFeedInfo.getVersion() != null && !gtfsFeedInfo.getVersion().isBlank()) {
             buffer.append("<tag k='gtfs:release_date' v='" + plugin.fixGtfsVersionDate(gtfsFeedInfo.getVersion()) + "' />\n");
         }
 


### PR DESCRIPTION
gtfs-osm-import used to crash when GTFS zip file didn't provide any feed_info.txt file.

As the content of this file is used only to set gtfs:release_date, we just don't set this tag when the file is missing.